### PR TITLE
Resolving CF Pipeline Issues, Cutting the Fat from Template.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.zip
 outputtemplate.*
+.idea/*
+.idea

--- a/functions/geojson_to_mvt/geojson_to_mvt.py
+++ b/functions/geojson_to_mvt/geojson_to_mvt.py
@@ -1,3 +1,0 @@
-
-
-#add stuff here

--- a/functions/json2mvt/json2mvt.py
+++ b/functions/json2mvt/json2mvt.py
@@ -1,7 +1,7 @@
 import json
 
 def lambda_handler(event, context):
-            return {
-                    'statusCode': 200,
-                    'body': json.dumps('Hello from Lambda!')
-                   }
+    return {
+            'statusCode': 200,
+            'body': json.dumps('Hello from Lambda!')
+           }

--- a/template.yaml
+++ b/template.yaml
@@ -71,7 +71,7 @@ Resources:
       Layers:
         - !Ref TippeCanoeLayer
       Events:
-        BucketEvent1:
+        BucketEvent2:
           Type: S3
           Properties:
             Bucket:
@@ -138,22 +138,22 @@ Resources:
             Method: GET
 
 
-  mapgetretriever:
-    Type: 'AWS::Serverless::Function'
-    Properties:
-      Handler: map_get_retriever.lambda_handler
-      Runtime: python3.8
-      CodeUri: functions/map_get_retriever/
-      Role: 'arn:aws:iam::958555546010:role/lambda-access-role'
-      Environment:
-        Variables:
-          DATA_SRC: !Select [1, !Split [":::", !GetAtt Bucket2.Arn]]
-      Events:
-        Api2:
-          Type: Api
-          Properties:
-            Path: /map
-            Method: GET
+#  mapgetretriever:
+#    Type: 'AWS::Serverless::Function'
+#    Properties:
+#      Handler: map_get_retriever.lambda_handler
+#      Runtime: python3.8
+#      CodeUri: functions/map_get_retriever/
+#      Role: 'arn:aws:iam::958555546010:role/lambda-access-role'
+#      Environment:
+#        Variables:
+#          DATA_SRC: !Select [1, !Split [":::", !GetAtt Bucket2.Arn]]
+#      Events:
+#        Api2:
+#          Type: Api
+#          Properties:
+#            Path: /map
+#            Method: GET
 
   # h5query -> h5extract
   Bucket1:


### PR DESCRIPTION
MapGetRetriever was designed and used for the SP presentation in the fall and does not need to be carried into the SAM app. It is now commented to deprecate it, will fully remove in the next couple of commits.

Resolving Circular Deadlock error propagated into CF Pipeline from template.yaml misconfiguration.