### PR TITLE
Adding dashboard JSON in test

### DIFF
--- a/metrics/dash.json
+++ b/metrics/dash.json
@@ -1,0 +1,484 @@
+{
+    "start": "-P3D",
+    "widgets": [
+        {
+            "type": "metric",
+            "x": 6,
+            "y": 48,
+            "width": 6,
+            "height": 6,
+            "properties": {
+                "metrics": [
+                    [ "AWS/DynamoDB", "SuccessfulRequestLatency", "TableName", "tide-maker-dev-stack-VectorTileBase-1J2RNBG91T9R9", "Operation", "Scan", { "yAxis": "left" } ],
+                    [ "...", "BatchWriteItem" ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "us-east-1",
+                "title": "Average DynamoDB Write vs Read Latency",
+                "period": 900,
+                "stat": "Average"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 0,
+            "y": 48,
+            "width": 6,
+            "height": 6,
+            "properties": {
+                "metrics": [
+                    [ "AWS/DynamoDB", "SuccessfulRequestLatency", "TableName", "tide-maker-dev-stack-VectorTileBase-1J2RNBG91T9R9", "Operation", "Scan", { "yAxis": "left" } ],
+                    [ "...", "BatchWriteItem" ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "us-east-1",
+                "title": "Maximum Dynamo Write vs Read Latency",
+                "period": 900,
+                "stat": "Maximum"
+            }
+        },
+        {
+            "type": "text",
+            "x": 0,
+            "y": 46,
+            "width": 18,
+            "height": 1,
+            "properties": {
+                "markdown": "\n# **DynamoDB**\n##  \n"
+            }
+        },
+        {
+            "type": "text",
+            "x": 0,
+            "y": 0,
+            "width": 18,
+            "height": 2,
+            "properties": {
+                "markdown": "\n# **Lambda**\n## All Functions\n"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 0,
+            "y": 2,
+            "width": 6,
+            "height": 6,
+            "properties": {
+                "metrics": [
+                    [ "AWS/Lambda", "Errors", "FunctionName", "tide-maker-dev-stack-h5extract-A7TJ3KQHSOVE" ],
+                    [ "...", "tide-maker-dev-stack-h5query-15DFX5S3BLZNW" ],
+                    [ "...", "tide-maker-dev-stack-json2mvt-1OT5I410HR0LT" ],
+                    [ "...", "tide-maker-dev-stack-streamlinesprocessor-F615E6JI77J7" ],
+                    [ "...", "tide-maker-dev-stack-tileapifunction-14AYC49RQ7X7X" ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "us-east-1",
+                "stat": "Sum",
+                "period": 300,
+                "title": "Backend Error Count (3-Day)"
+            }
+        },
+        {
+            "type": "text",
+            "x": 0,
+            "y": 47,
+            "width": 18,
+            "height": 1,
+            "properties": {
+                "markdown": "\n#  \n## VectorTileBase\n"
+            }
+        },
+        {
+            "type": "text",
+            "x": 0,
+            "y": 32,
+            "width": 18,
+            "height": 1,
+            "properties": {
+                "markdown": "\n#  \n## H5Extract\n"
+            }
+        },
+        {
+            "type": "text",
+            "x": 0,
+            "y": 25,
+            "width": 18,
+            "height": 1,
+            "properties": {
+                "markdown": "\n#  \n## StreamlineProcessor\n"
+            }
+        },
+        {
+            "type": "text",
+            "x": 0,
+            "y": 39,
+            "width": 18,
+            "height": 1,
+            "properties": {
+                "markdown": "\n#  \n## H5Query\n"
+            }
+        },
+        {
+            "type": "text",
+            "x": 0,
+            "y": 18,
+            "width": 18,
+            "height": 1,
+            "properties": {
+                "markdown": "\n#  \n## json2mvt\n"
+            }
+        },
+        {
+            "type": "text",
+            "x": 0,
+            "y": 11,
+            "width": 18,
+            "height": 1,
+            "properties": {
+                "markdown": "\n#  \n## tileAPIfunction\n"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 6,
+            "y": 2,
+            "width": 3,
+            "height": 6,
+            "properties": {
+                "metrics": [
+                    [ "AWS/Lambda", "Errors", { "color": "#d62728" } ]
+                ],
+                "view": "singleValue",
+                "region": "us-east-1",
+                "title": "System Wide Errors (7-Day)",
+                "period": 604800,
+                "stat": "Sum",
+                "stacked": false
+            }
+        },
+        {
+            "type": "metric",
+            "x": 3,
+            "y": 40,
+            "width": 3,
+            "height": 3,
+            "properties": {
+                "metrics": [
+                    [ "AWS/Lambda", "Duration", "FunctionName", "tide-maker-dev-stack-h5extract-A7TJ3KQHSOVE", { "visible": false } ],
+                    [ "...", "tide-maker-dev-stack-h5query-15DFX5S3BLZNW" ],
+                    [ "...", "tide-maker-dev-stack-json2mvt-1OT5I410HR0LT", { "visible": false } ],
+                    [ "...", "tide-maker-dev-stack-streamlinesprocessor-F615E6JI77J7", { "visible": false } ],
+                    [ "...", "tide-maker-dev-stack-tileapifunction-14AYC49RQ7X7X", { "visible": false } ]
+                ],
+                "view": "singleValue",
+                "region": "us-east-1",
+                "title": "Average Duration (7-Day)",
+                "period": 604800,
+                "stat": "Average"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 0,
+            "y": 40,
+            "width": 3,
+            "height": 3,
+            "properties": {
+                "metrics": [
+                    [ "AWS/Lambda", "Invocations", "FunctionName", "tide-maker-dev-stack-h5extract-A7TJ3KQHSOVE", { "visible": false } ],
+                    [ "...", "tide-maker-dev-stack-h5query-15DFX5S3BLZNW" ],
+                    [ "...", "tide-maker-dev-stack-json2mvt-1OT5I410HR0LT", { "visible": false } ],
+                    [ "...", "tide-maker-dev-stack-tileapifunction-14AYC49RQ7X7X", { "visible": false } ],
+                    [ "...", "tide-maker-dev-stack-streamlinesprocessor-F615E6JI77J7", { "visible": false } ]
+                ],
+                "view": "singleValue",
+                "region": "us-east-1",
+                "title": "Invocations (7-Days)",
+                "period": 604800,
+                "stat": "Sum"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 6,
+            "y": 40,
+            "width": 6,
+            "height": 6,
+            "properties": {
+                "metrics": [
+                    [ "AWS/Lambda", "ConcurrentExecutions", "FunctionName", "tide-maker-dev-stack-h5extract-A7TJ3KQHSOVE", "Resource", "tide-maker-dev-stack-h5extract-A7TJ3KQHSOVE", { "visible": false } ],
+                    [ "...", "tide-maker-dev-stack-h5query-15DFX5S3BLZNW", ".", "tide-maker-dev-stack-h5query-15DFX5S3BLZNW" ],
+                    [ "...", "tide-maker-dev-stack-json2mvt-1OT5I410HR0LT", ".", "tide-maker-dev-stack-json2mvt-1OT5I410HR0LT", { "visible": false } ],
+                    [ "...", "tide-maker-dev-stack-streamlinesprocessor-F615E6JI77J7", ".", "tide-maker-dev-stack-streamlinesprocessor-F615E6JI77J7", { "visible": false } ],
+                    [ "...", "tide-maker-dev-stack-tileapifunction-14AYC49RQ7X7X", ".", "tide-maker-dev-stack-tileapifunction-14AYC49RQ7X7X", { "visible": false } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "us-east-1",
+                "period": 300,
+                "title": "Concurrent Function Invocations (3-Day)",
+                "stat": "Sum"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 0,
+            "y": 33,
+            "width": 3,
+            "height": 3,
+            "properties": {
+                "metrics": [
+                    [ "AWS/Lambda", "Invocations", "FunctionName", "tide-maker-dev-stack-h5extract-A7TJ3KQHSOVE" ]
+                ],
+                "view": "singleValue",
+                "region": "us-east-1",
+                "title": "Invocations (7-Days)",
+                "period": 604800,
+                "stat": "Sum"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 3,
+            "y": 33,
+            "width": 3,
+            "height": 3,
+            "properties": {
+                "metrics": [
+                    [ "AWS/Lambda", "Duration", "FunctionName", "tide-maker-dev-stack-h5extract-A7TJ3KQHSOVE" ]
+                ],
+                "view": "singleValue",
+                "region": "us-east-1",
+                "title": "Average Duration (7-Day)",
+                "period": 604800,
+                "stat": "Average"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 6,
+            "y": 33,
+            "width": 6,
+            "height": 6,
+            "properties": {
+                "view": "timeSeries",
+                "stacked": false,
+                "metrics": [
+                    [ "AWS/Lambda", "ConcurrentExecutions", "FunctionName", "tide-maker-dev-stack-h5extract-A7TJ3KQHSOVE", "Resource", "tide-maker-dev-stack-h5extract-A7TJ3KQHSOVE" ]
+                ],
+                "region": "us-east-1",
+                "period": 300,
+                "title": "Concurrent Function Invocations (3-Day)"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 0,
+            "y": 12,
+            "width": 3,
+            "height": 3,
+            "properties": {
+                "metrics": [
+                    [ "AWS/Lambda", "Invocations", "FunctionName", "tide-maker-dev-stack-h5extract-A7TJ3KQHSOVE", { "visible": false } ],
+                    [ "...", "tide-maker-dev-stack-h5query-15DFX5S3BLZNW", { "visible": false } ],
+                    [ "...", "tide-maker-dev-stack-json2mvt-1OT5I410HR0LT", { "visible": false } ],
+                    [ "...", "tide-maker-dev-stack-tileapifunction-14AYC49RQ7X7X" ],
+                    [ "...", "tide-maker-dev-stack-streamlinesprocessor-F615E6JI77J7", { "visible": false } ]
+                ],
+                "view": "singleValue",
+                "region": "us-east-1",
+                "title": "Invocations (7-Days)",
+                "period": 604800,
+                "stat": "Sum"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 3,
+            "y": 12,
+            "width": 3,
+            "height": 3,
+            "properties": {
+                "metrics": [
+                    [ "AWS/Lambda", "Duration", "FunctionName", "tide-maker-dev-stack-h5extract-A7TJ3KQHSOVE", { "visible": false } ],
+                    [ "...", "tide-maker-dev-stack-h5query-15DFX5S3BLZNW", { "visible": false } ],
+                    [ "...", "tide-maker-dev-stack-json2mvt-1OT5I410HR0LT", { "visible": false } ],
+                    [ "...", "tide-maker-dev-stack-streamlinesprocessor-F615E6JI77J7", { "visible": false } ],
+                    [ "...", "tide-maker-dev-stack-tileapifunction-14AYC49RQ7X7X" ]
+                ],
+                "view": "singleValue",
+                "region": "us-east-1",
+                "title": "Average Duration (7-Day)",
+                "period": 604800,
+                "stat": "Average"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 6,
+            "y": 12,
+            "width": 6,
+            "height": 6,
+            "properties": {
+                "metrics": [
+                    [ "AWS/Lambda", "ConcurrentExecutions", "FunctionName", "tide-maker-dev-stack-h5extract-A7TJ3KQHSOVE", "Resource", "tide-maker-dev-stack-h5extract-A7TJ3KQHSOVE", { "visible": false } ],
+                    [ "...", "tide-maker-dev-stack-h5query-15DFX5S3BLZNW", ".", "tide-maker-dev-stack-h5query-15DFX5S3BLZNW", { "visible": false } ],
+                    [ "...", "tide-maker-dev-stack-json2mvt-1OT5I410HR0LT", ".", "tide-maker-dev-stack-json2mvt-1OT5I410HR0LT", { "visible": false } ],
+                    [ "...", "tide-maker-dev-stack-streamlinesprocessor-F615E6JI77J7", ".", "tide-maker-dev-stack-streamlinesprocessor-F615E6JI77J7", { "visible": false } ],
+                    [ "...", "tide-maker-dev-stack-tileapifunction-14AYC49RQ7X7X", ".", "tide-maker-dev-stack-tileapifunction-14AYC49RQ7X7X", { "stat": "Sum" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "us-east-1",
+                "period": 300,
+                "title": "Concurrent Function Invocations (3-Day)",
+                "stat": "Average"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 0,
+            "y": 19,
+            "width": 3,
+            "height": 3,
+            "properties": {
+                "metrics": [
+                    [ "AWS/Lambda", "Invocations", "FunctionName", "tide-maker-dev-stack-h5extract-A7TJ3KQHSOVE", { "visible": false } ],
+                    [ "...", "tide-maker-dev-stack-h5query-15DFX5S3BLZNW", { "visible": false } ],
+                    [ "...", "tide-maker-dev-stack-json2mvt-1OT5I410HR0LT" ],
+                    [ "...", "tide-maker-dev-stack-tileapifunction-14AYC49RQ7X7X", { "visible": false } ],
+                    [ "...", "tide-maker-dev-stack-streamlinesprocessor-F615E6JI77J7", { "visible": false } ]
+                ],
+                "view": "singleValue",
+                "region": "us-east-1",
+                "title": "Invocations (7-Days)",
+                "period": 604800,
+                "stat": "Sum"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 3,
+            "y": 19,
+            "width": 3,
+            "height": 3,
+            "properties": {
+                "metrics": [
+                    [ "AWS/Lambda", "Duration", "FunctionName", "tide-maker-dev-stack-h5extract-A7TJ3KQHSOVE", { "visible": false } ],
+                    [ "...", "tide-maker-dev-stack-h5query-15DFX5S3BLZNW", { "visible": false } ],
+                    [ "...", "tide-maker-dev-stack-json2mvt-1OT5I410HR0LT" ],
+                    [ "...", "tide-maker-dev-stack-streamlinesprocessor-F615E6JI77J7", { "visible": false } ],
+                    [ "...", "tide-maker-dev-stack-tileapifunction-14AYC49RQ7X7X", { "visible": false } ]
+                ],
+                "view": "singleValue",
+                "region": "us-east-1",
+                "title": "Average Duration (7-Day)",
+                "period": 604800,
+                "stat": "Average"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 6,
+            "y": 19,
+            "width": 6,
+            "height": 6,
+            "properties": {
+                "metrics": [
+                    [ "AWS/Lambda", "ConcurrentExecutions", "FunctionName", "tide-maker-dev-stack-h5extract-A7TJ3KQHSOVE", "Resource", "tide-maker-dev-stack-h5extract-A7TJ3KQHSOVE", { "visible": false } ],
+                    [ "...", "tide-maker-dev-stack-h5query-15DFX5S3BLZNW", ".", "tide-maker-dev-stack-h5query-15DFX5S3BLZNW", { "visible": false } ],
+                    [ "...", "tide-maker-dev-stack-json2mvt-1OT5I410HR0LT", ".", "tide-maker-dev-stack-json2mvt-1OT5I410HR0LT" ],
+                    [ "...", "tide-maker-dev-stack-streamlinesprocessor-F615E6JI77J7", ".", "tide-maker-dev-stack-streamlinesprocessor-F615E6JI77J7", { "visible": false } ],
+                    [ "...", "tide-maker-dev-stack-tileapifunction-14AYC49RQ7X7X", ".", "tide-maker-dev-stack-tileapifunction-14AYC49RQ7X7X", { "visible": false } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "us-east-1",
+                "period": 300,
+                "title": "Concurrent Function Invocations (3-Day)",
+                "stat": "Sum"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 0,
+            "y": 26,
+            "width": 3,
+            "height": 3,
+            "properties": {
+                "metrics": [
+                    [ "AWS/Lambda", "Invocations", "FunctionName", "tide-maker-dev-stack-h5extract-A7TJ3KQHSOVE", { "visible": false } ],
+                    [ "...", "tide-maker-dev-stack-h5query-15DFX5S3BLZNW", { "visible": false } ],
+                    [ "...", "tide-maker-dev-stack-json2mvt-1OT5I410HR0LT", { "visible": false } ],
+                    [ "...", "tide-maker-dev-stack-tileapifunction-14AYC49RQ7X7X", { "visible": false } ],
+                    [ "...", "tide-maker-dev-stack-streamlinesprocessor-F615E6JI77J7" ]
+                ],
+                "view": "singleValue",
+                "region": "us-east-1",
+                "title": "Invocations (7-Days)",
+                "period": 604800,
+                "stat": "Sum"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 3,
+            "y": 26,
+            "width": 3,
+            "height": 3,
+            "properties": {
+                "metrics": [
+                    [ "AWS/Lambda", "Duration", "FunctionName", "tide-maker-dev-stack-h5extract-A7TJ3KQHSOVE", { "visible": false } ],
+                    [ "...", "tide-maker-dev-stack-h5query-15DFX5S3BLZNW", { "visible": false } ],
+                    [ "...", "tide-maker-dev-stack-json2mvt-1OT5I410HR0LT", { "visible": false } ],
+                    [ "...", "tide-maker-dev-stack-streamlinesprocessor-F615E6JI77J7" ],
+                    [ "...", "tide-maker-dev-stack-tileapifunction-14AYC49RQ7X7X", { "visible": false } ]
+                ],
+                "view": "singleValue",
+                "region": "us-east-1",
+                "title": "Average Duration (7-Day)",
+                "period": 604800,
+                "stat": "Average"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 6,
+            "y": 26,
+            "width": 6,
+            "height": 6,
+            "properties": {
+                "metrics": [
+                    [ "AWS/Lambda", "ConcurrentExecutions", "FunctionName", "tide-maker-dev-stack-h5extract-A7TJ3KQHSOVE", "Resource", "tide-maker-dev-stack-h5extract-A7TJ3KQHSOVE", { "visible": false } ],
+                    [ "...", "tide-maker-dev-stack-h5query-15DFX5S3BLZNW", ".", "tide-maker-dev-stack-h5query-15DFX5S3BLZNW", { "visible": false } ],
+                    [ "...", "tide-maker-dev-stack-json2mvt-1OT5I410HR0LT", ".", "tide-maker-dev-stack-json2mvt-1OT5I410HR0LT", { "visible": false } ],
+                    [ "...", "tide-maker-dev-stack-streamlinesprocessor-F615E6JI77J7", ".", "tide-maker-dev-stack-streamlinesprocessor-F615E6JI77J7" ],
+                    [ "...", "tide-maker-dev-stack-tileapifunction-14AYC49RQ7X7X", ".", "tide-maker-dev-stack-tileapifunction-14AYC49RQ7X7X", { "visible": false } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "us-east-1",
+                "period": 300,
+                "title": "Concurrent Function Invocations (3-Day)",
+                "stat": "Sum"
+            }
+        },
+        {
+            "type": "log",
+            "x": 0,
+            "y": 8,
+            "width": 24,
+            "height": 3,
+            "properties": {
+                "query": "SOURCE '/aws/lambda/tide-maker-dev-stack-h5extract-A7TJ3KQHSOVE' | SOURCE '/aws/lambda/tide-maker-dev-stack-h5query-15DFX5S3BLZNW' | SOURCE '/aws/lambda/tide-maker-dev-stack-json2mvt-1OT5I410HR0LT' | SOURCE '/aws/lambda/tide-maker-dev-stack-streamlinesprocessor-F615E6JI77J7' | SOURCE '/aws/lambda/tide-maker-dev-stack-tileapifunction-14AYC49RQ7X7X' | filter @type = \"REPORT\"\n| stats max(@memorySize / 1024 / 1024) as provisonedMemoryMB,\n\n\n\n    min(@maxMemoryUsed / 1024 / 1024) as smallestMemoryRequestMB,\n\n\n\n    avg(@maxMemoryUsed / 1024 / 1024) as avgMemoryUsedMB,\n\n\n\n    max(@maxMemoryUsed / 1024 / 1024) as maxMemoryUsedMB,\n\n\n\n    provisonedMemoryMB - maxMemoryUsedMB as overProvisionedMB",
+                "region": "us-east-1",
+                "stacked": false,
+                "view": "table",
+                "title": "Memory Efficiency Statistics"
+            }
+        }
+    ]
+}

--- a/template.yaml
+++ b/template.yaml
@@ -283,3 +283,15 @@ Resources:
           Value: !Ref VectorTileBase
         - Name: 'Operation'
           Value: 'BatchWriteItem'
+
+
+
+  DashboardMonitor:
+    Type: 'AWS::CloudWatch::Dashboard'
+    Properties:
+      DashboardBody:
+        Fn::Transform:
+          Name: AWS::Include
+          Parameters:
+            Location: ./metrics/dash.json
+      DashboardName: 'OceansServerless-Drill-Down'


### PR DESCRIPTION
@msh1011 Adding for cross-check. Dashboards from CloudWatch are finicky....they don't have a YAML structure. AWS stupidly uses them as literal JSON strings. The dashboard I Created is ~500 lines so I believe this will ref it from template.yaml without shoving it in there. Linted fine, not positive it will work.